### PR TITLE
Misspelled source and image not present.

### DIFF
--- a/Web Dev/Css_learning/The_code_magazine/index.html
+++ b/Web Dev/Css_learning/The_code_magazine/index.html
@@ -37,7 +37,7 @@
             <!-- <sub> and <sup> are subscript  and super script tags for demostrating 10th and C02 type symbols -->
           </p>
 
-          <img scr="img/coding.jpg"
+          <img src="coding.jpg"
             alt="this is a coding image"
             width="600"
             height="320"


### PR DESCRIPTION
The two errors were that the `src` tag was missspelled as `scr` and that the images wasn't present at the directory.